### PR TITLE
Adjust header text size for iPad mini landscape

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
   .track{display:flex;gap:16px;padding:16px;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth}
   .slide{position:relative;flex:0 0 92%;max-width:92%;height:72vw;max-height:660px;scroll-snap-align:center;border-radius:16px;overflow:hidden;background:linear-gradient(135deg,#23232b 0%,#1a1a21 100%);border:1px solid var(--border)}
   @media (min-width:1024px){ .slide{flex-basis:48%;max-width:48%;height:520px} }
+  @media (orientation: landscape) and (max-height: 744px){
+    h1{font-size:22px}
+    .sub{font-size:14px}
+  }
   .imgph{width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:#80838f;font-size:18px;background:repeating-linear-gradient(45deg,#202028,#202028 12px,#1a1a21 12px,#1a1a21 24px)}
   .overlay{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(180deg,transparent,rgba(0,0,0,.55) 30%,rgba(0,0,0,.75) 78%);color:#fff;padding:16px 16px 14px}
   .overlay .name{font-size:var(--fs-name);font-weight:800;line-height:1.25;margin:0 0 6px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}


### PR DESCRIPTION
## Summary
- shrink heading and subtext fonts on short landscape tablets to prevent vertical scroll while leaving tab sizes unchanged

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e43a5b70833081d4f3f44e23f931