### PR TITLE
feat: add offline support

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <meta name="theme-color" content="#111">
 <title>La Casa 电子菜单</title>
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+<link rel="manifest" href="manifest.webmanifest">
 <style>
   :root{
     --bg:#0f0f12; --panel:#14141a; --ink:#f1f1f3; --muted:#b6b8c0;
@@ -450,6 +451,13 @@ function drawRingText(ctx, text, radius, startAngle, spacingPx){
   }
   ctx.restore();
 }
+</script>
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('sw.js');
+    });
+  }
 </script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "La Casa 菜单",
+  "short_name": "La Casa",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#0f0f12",
+  "theme_color": "#111111",
+  "icons": [
+    {
+      "src": "apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,51 @@
+const CACHE_NAME = 'lacasa-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/apple-touch-icon.png',
+  '/images/apple-touch-icon.png',
+  '/images/cubaney-10.jpg',
+  '/images/cubaney-20.jpg',
+  '/images/hot-1.jpg',
+  '/images/ice-1.jpg',
+  '/images/rare-1.jpg',
+  '/images/rare-2.jpg',
+  '/images/rare-3.jpg',
+  '/images/rare-4.jpg',
+  '/images/rare-5.jpg',
+  '/images/rare-6.jpg',
+  '/images/rose-1.jpg',
+  '/images/rose-2.jpg',
+  '/images/rw-1.jpg',
+  '/images/rw-2.jpg',
+  '/images/rw-3.jpg',
+  '/images/rw-4.jpg',
+  '/images/santiago-20.jpg',
+  '/images/snack-1.jpg',
+  '/images/snack-2.jpg',
+  '/images/snack-3.jpg',
+  '/images/treasure.jpg',
+  '/images/ww-1.jpg',
+  '/images/ww-2.jpg',
+  '/images/ww-3.jpg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest and service worker registration to index.html
- cache static assets via a new service worker for offline use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fa22edf48330b4b16a415ca52d31