### PR TITLE
feat: hide carousel arrows at edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,8 @@ function updateArrows(){
   const atStart = track.scrollLeft <= 1;
   const atEnd = track.scrollLeft + track.clientWidth >= track.scrollWidth - 1;
   prevBtn.disabled = atStart; nextBtn.disabled = atEnd;
+  prevBtn.style.display = atStart ? 'none' : 'grid';
+  nextBtn.style.display = atEnd ? 'none' : 'grid';
 }
 track.addEventListener('scroll', updateArrows);
 window.addEventListener('resize', updateArrows);


### PR DESCRIPTION
## Summary
- Hide next/prev arrows when carousel is at the beginning or end

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fbcc0384833089f1cbd68ae3805f