### PR TITLE
fix carousel arrow visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,8 +335,10 @@ function updateArrows(){
   const atStart = track.scrollLeft <= 1;
   const atEnd = track.scrollLeft + track.clientWidth >= track.scrollWidth - 1;
   prevBtn.disabled = atStart; nextBtn.disabled = atEnd;
-  prevBtn.style.display = atStart ? 'none' : 'grid';
-  nextBtn.style.display = atEnd ? 'none' : 'grid';
+  prevBtn.style.visibility = atStart ? 'hidden' : 'visible';
+  prevBtn.style.pointerEvents = atStart ? 'none' : 'auto';
+  nextBtn.style.visibility = atEnd ? 'hidden' : 'visible';
+  nextBtn.style.pointerEvents = atEnd ? 'none' : 'auto';
 }
 track.addEventListener('scroll', updateArrows);
 window.addEventListener('resize', updateArrows);


### PR DESCRIPTION
## Summary
- keep right arrow positioned when the first carousel slide is active by hiding arrows via visibility
- prevent hidden arrows from blocking interactions by disabling pointer events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe795250833082731b5c61b0844c