### PR TITLE
fix: allow horizontal swipe in standalone mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,14 +185,23 @@ document.addEventListener('touchend', e => {
 document.addEventListener('dblclick', e=>e.preventDefault(), {passive:false});
 document.addEventListener('contextmenu', e=>e.preventDefault());
 
-let startY = 0;
-document.addEventListener('touchstart', e=>{ startY = e.touches[0].clientY; }, {passive:false});
+let startY = 0, startX = 0;
+document.addEventListener('touchstart', e=>{
+  const t = e.touches[0];
+  startY = t.clientY;
+  startX = t.clientX;
+}, {passive:false});
 document.addEventListener('touchmove', e=>{
-  const y = e.touches[0].clientY;
-  const atTop = window.scrollY === 0;
-  const atBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
-  if ((atTop && y > startY) || (atBottom && y < startY)) {
-    e.preventDefault();
+  const t = e.touches[0];
+  const deltaY = t.clientY - startY;
+  const deltaX = t.clientX - startX;
+  // 仅在垂直滑动时阻止顶/底部回弹，保留横向滑动能力
+  if (Math.abs(deltaY) > Math.abs(deltaX)) {
+    const atTop = window.scrollY === 0;
+    const atBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
+    if ((atTop && deltaY > 0) || (atBottom && deltaY < 0)) {
+      e.preventDefault();
+    }
   }
 }, {passive:false});
 


### PR DESCRIPTION
## Summary
- prevent global touchmove listener from blocking horizontal swipes
- retain vertical overscroll lock to keep native app feel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ffa7a2bc8330b621e49ff2f6c401