### PR TITLE
Fix carousel arrow visibility after tab change

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,8 @@ function drawCarousel(reset=false){
   track.innerHTML='';
   MENU.filter(m=>m.cat===activeCat).forEach(m=> track.appendChild(slideCard(m)));
   if(reset){ track.scrollTo({left:0, top:0, behavior:'auto'}); }
-  updateArrows();
+  // Defer arrow update to ensure new slides have rendered
+  requestAnimationFrame(updateArrows);
 }
 drawCarousel(true);
 


### PR DESCRIPTION
## Summary
- defer arrow update until after slides render so arrows hide correctly when switching tabs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c600a0cc3c8330b14247366e603b2d