### PR TITLE
fix: ensure carousel arrows hide correctly in Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,10 +371,14 @@ function updateArrows(){
   nextBtn.style.pointerEvents = atEnd ? 'none' : 'auto';
 }
 let arrowRaf;
+let arrowTimeout;
 track.addEventListener('scroll', () => {
   cancelAnimationFrame(arrowRaf);
   arrowRaf = requestAnimationFrame(updateArrows);
+  clearTimeout(arrowTimeout);
+  arrowTimeout = setTimeout(updateArrows, 100);
 });
+track.addEventListener('scrollend', updateArrows);
 window.addEventListener('resize', updateArrows);
 
 prevBtn.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- debounce scroll events and add `scrollend` listener to reliably hide carousel arrows at edges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c650bf58ec83309f68f33d5a68379b