### PR TITLE
Add early iPad compatible menu page

### DIFF
--- a/ipad1.html
+++ b/ipad1.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>La Casa 电子菜单 - iPad 1 兼容版</title>
+<style>
+body { font-family: Helvetica, Arial, sans-serif; margin:0; background:#0f0f12; color:#f1f1f3; }
+header { background:#14141a; padding:10px 16px; }
+h1 { font-size:24px; margin:0; }
+#tabs { padding:8px; background:#1b1b23; overflow-x:auto; white-space:nowrap; }
+#tabs button { background:#23232b; color:#fff; border:1px solid #444; border-radius:12px; padding:8px 14px; margin-right:6px; }
+#tabs button.active { background:#a88146; border-color:#a88146; }
+#menu { padding:16px; }
+.item { border:1px solid #333; border-radius:12px; padding:12px; margin-bottom:16px; background:#14141a; }
+.item img { width:100%; height:auto; border-radius:8px; }
+.item-title { font-size:20px; font-weight:bold; margin:8px 0 4px; }
+.item-desc { font-size:16px; color:#b6b8c0; margin:0 0 8px; }
+.item-actions { margin-top:8px; }
+#cartBtn { position:fixed; right:20px; bottom:20px; padding:14px 20px; border:none; border-radius:28px; background:#a88146; color:#fff; font-size:18px; }
+#cartPanel { position:fixed; right:0; top:0; bottom:0; width:300px; background:#14141a; border-left:1px solid #444; overflow:auto; display:none; padding:16px; }
+.cart-item { border-bottom:1px dashed #444; padding:8px 0; }
+.cart-item-title { font-size:18px; margin:0 0 4px; }
+.cart-item-spec { color:#b6b8c0; font-size:16px; }
+.cart-item-qty { display:flex; align-items:center; margin-top:6px; }
+.cart-item-qty button { width:32px; height:32px; }
+.summary { font-size:20px; margin-top:12px; }
+.orders { padding:16px; }
+.order-card { border:1px solid #333; margin-bottom:12px; padding:12px; }
+</style>
+</head>
+<body>
+<header>
+<h1>La Casa 菜单</h1>
+</header>
+<div id="tabs"></div>
+<div id="menu"></div>
+<button id="cartBtn">购物车 · 0</button>
+<div id="cartPanel">
+  <h2>购物车</h2>
+  <div id="cartItems"></div>
+  <div class="summary">总计：<span id="cartTotal">¥0</span></div>
+  <button id="placeOrder">下单</button>
+  <button id="closeCart">关闭</button>
+  <h2>历史订单</h2>
+  <div id="ordersList"></div>
+</div>
+<script>
+if(!window.requestAnimationFrame){
+  window.requestAnimationFrame = function(cb){ return setTimeout(cb,16); };
+}
+var CATS = [
+  {id:'coffee',name:'精品咖啡 Coffee'}, {id:'rum',name:'古巴朗姆 Rum for Cigar'},
+  {id:'sig',name:'La Casa 特调 Signature Cocktails'},
+  {id:'soft',name:'软饮 Soft Drinks'},
+  {id:'rose',name:'桃红葡萄酒 Rosé'}, {id:'rare',name:'小众烈酒 Rare Spirits'},
+  {id:'white',name:'白葡萄酒 White Wine'}, {id:'red',name:'红葡萄酒 Red Wine'},
+  {id:'snack',name:'茄客小食'},
+  {id:'easter',name:'La Casa 小彩蛋'}
+];
+var MENU = [
+  {id:'ice-1',cat:'coffee',title:'极品冰滴｜淡雅芳香系（百搭雪茄）',desc:'0℃冰水滴滤 1 天，发酵 3–7 天，口感清冽冰爽。',variants:[{label:'杯',unit:'/杯',price:11900}],img:'images/ice-1.jpg'},
+  {id:'ice-2',cat:'coffee',title:'极品冰滴｜果香红茶系（提升风味）',desc:'果香跳跃、红茶感明显，激发雪茄香气。',variants:[{label:'杯',unit:'/杯',price:11900}],img:'images/ice-1.jpg'},
+  {id:'ice-3',cat:'coffee',title:'极品冰滴｜浆果活泼系（适配强度）',desc:'更有劲道的风味线，适配高强度雪茄。',variants:[{label:'杯',unit:'/杯',price:11900}],img:'images/ice-1.jpg'},
+  {id:'hot-1',cat:'coffee',title:'精品手冲｜万花',desc:'参赛级参数调校，层次丰富。',variants:[{label:'杯',unit:'/杯',price:7900}],img:'images/hot-1.jpg'},
+  {id:'hot-2',cat:'coffee',title:'精品手冲｜耶加莱德',desc:'花果香突出，酸甜平衡。',variants:[{label:'杯',unit:'/杯',price:7900}],img:'images/hot-1.jpg'},
+  {id:'hot-3',cat:'coffee',title:'精品手冲｜桃莓优格',desc:'桃与莓果气息，酸乳感顺滑。',variants:[{label:'杯',unit:'/杯',price:7900}],img:'images/hot-1.jpg'},
+  {id:'cubaney-10',cat:'rum',title:'古巴邑 10 年',desc:'顺喉易饮，入门之选。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:98000}],img:'images/cubaney-10.jpg'},
+  {id:'cubaney-20',cat:'rum',title:'古巴邑 20 年',desc:'陈年香气浓郁，回味悠长。',variants:[{label:'瓶',unit:'/瓶',price:339600}],img:'images/cubaney-20.jpg'},
+  {id:'santiago-20',cat:'rum',title:'圣地亚哥 20 年（绝版）',desc:'加勒比热辣与陈年复杂度的平衡。',variants:[{label:'瓶',unit:'/瓶',price:655900}],img:'images/santiago-20.jpg'},
+  {id:'treasure',cat:'rum',title:'金银岛宝藏（国礼）',desc:'收藏级古巴朗姆，气派之选。',variants:[{label:'瓶',unit:'/瓶',price:1799900}],img:'images/treasure.jpg'},
+  {id:'ww-1',cat:'white',title:'南十字星 马尔堡 长相思 干白 2021',desc:'单宁近零，激发味蕾，适合灰茄前/中。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:32800}],img:'images/ww-1.jpg'},
+  {id:'ww-2',cat:'white',title:'勃艮第 法拉利酒庄 小夏布利 村庄 干白 2023',desc:'矿物感清晰，酸度爽脆。',variants:[{label:'瓶',unit:'/瓶',price:68800}],img:'images/ww-2.jpg'},
+  {id:'ww-3',cat:'white',title:'法国 杜索 传统佳酿 香槟',desc:'气泡细腻，活力十足。',variants:[{label:'瓶',unit:'/瓶',price:98900}],img:'images/ww-3.jpg'},
+  {id:'rw-1',cat:'red',title:'摩尔多瓦 梅洛 干红 2012',desc:'适合灰茄后饮用。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:32800}],img:'images/rw-1.jpg'},
+  {id:'rw-2',cat:'red',title:'法芭雅 蒙特布查诺 红 2022',desc:'成熟红果与香料气息。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rw-2.jpg'},
+  {id:'rw-3',cat:'red',title:'曼都利亚 利嘉 红 2021',desc:'饱满酒体，余味绵长。',variants:[{label:'瓶',unit:'/瓶',price:49800}],img:'images/rw-3.jpg'},
+  {id:'rw-4',cat:'red',title:'格兰吉雅 经典 阿玛罗尼 红 2022',desc:'力度与甜美并存。',variants:[{label:'瓶',unit:'/瓶',price:98900}],img:'images/rw-4.jpg'},
+  {id:'rose-1',cat:'rose',title:'特莎蒂洛 蓝布斯科 桃红起泡 NV',desc:'全程兼容雪茄，轻松畅饮。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rose-1.jpg'},
+  {id:'rose-2',cat:'rose',title:'时尚控 桃红起泡',desc:'派对气质，愉悦开胃。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rose-2.jpg'},
+  {id:'rare-1',cat:'rare',title:'狂爱芒果甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-1.jpg'},
+  {id:'rare-2',cat:'rare',title:'狂爱椰子甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-2.jpg'},
+  {id:'rare-3',cat:'rare',title:'狂爱甜瓜甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-3.jpg'},
+  {id:'rare-4',cat:'rare',title:'狂爱石榴甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-4.jpg'},
+  {id:'rare-5',cat:'rare',title:'拉达米尔 白兰地',desc:'适合灰茄中/后。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:48000}],img:'images/rare-5.jpg'},
+  {id:'rare-6',cat:'rare',title:'梅斯赫蒂 五年 白兰地',desc:'顺滑果干风味。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:48000}],img:'images/rare-6.jpg'},
+  {id:'mojito',cat:'sig',title:'比那尔德里奥的莫吉托',desc:'Pinar del Río Mojito · 与雪茄全程兼容。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
+  {id:'cubalibre',cat:'sig',title:'自由古巴之烟草时光',desc:'Cigar Time of Cuba Libre · 经典新演绎。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
+  {id:'castle',cat:'sig',title:'夜之古堡',desc:'Castle in the Night · 夜色与余味。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
+  {id:'snack-1',cat:'snack',title:'坚果拼盘',desc:'小胡桃、松子、杏仁、腰果等随机拼盘。',variants:[{label:'盘',unit:'/盘',price:8800}],img:'images/snack-1.jpg'},
+  {id:'snack-2',cat:'snack',title:'伊比利亚火腿',desc:'咸香与脂香，雪茄绝配。',variants:[{label:'盘',unit:'/盘',price:19800}],img:'images/snack-2.jpg'},
+  {id:'snack-3',cat:'snack',title:'黑松露饼干',desc:'幽微松露香气，酥脆可口。',variants:[{label:'盘',unit:'/盘',price:4900}],img:'images/snack-3.jpg'},
+  {id:'bucket-1',cat:'easter',title:'好彩头冰桶｜好运杯',desc:'含可饮白桦树汁，可冰镇任意酒水，会发光。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
+  {id:'bucket-2',cat:'easter',title:'好彩头冰桶｜招财杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
+  {id:'bucket-3',cat:'easter',title:'好彩头冰桶｜吉祥杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
+  {id:'bucket-4',cat:'easter',title:'好彩头冰桶｜平安杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'}
+];
+var SOFT_DRINKS = [
+  {id:'soft-coke',title:'可乐',variants:[{label:'瓶',unit:'/瓶',price:3000}]},
+  {id:'soft-soda',title:'苏打水',variants:[{label:'瓶',unit:'/瓶',price:3000}]}
+];
+function fmtY(n){ return '¥' + (n/100).toFixed(0); }
+var activeCat = CATS[0].id;
+var cartBtn = document.getElementById('cartBtn');
+var tabs = document.getElementById('tabs');
+var menuEl = document.getElementById('menu');
+var cartPanel = document.getElementById('cartPanel');
+var cartItems = document.getElementById('cartItems');
+var cartTotal = document.getElementById('cartTotal');
+var ordersList = document.getElementById('ordersList');
+var CART = JSON.parse(localStorage.getItem('LC_CART_TAB_V9') || '[]');
+var ORDERS = JSON.parse(localStorage.getItem('LC_ORDERS') || '[]');
+function saveCart(){ localStorage.setItem('LC_CART_TAB_V9', JSON.stringify(CART)); }
+function saveOrders(){ localStorage.setItem('LC_ORDERS', JSON.stringify(ORDERS)); }
+function renderTabs(){
+  tabs.innerHTML = '';
+  for(var i=0;i<CATS.length;i++){
+    (function(cat){
+      var b = document.createElement('button');
+      b.appendChild(document.createTextNode(cat.name));
+      if(activeCat===cat.id) b.className='active';
+      b.onclick = function(){ activeCat=cat.id; renderTabs(); renderMenu(); };
+      tabs.appendChild(b);
+    })(CATS[i]);
+  }
+}
+function renderMenu(){
+  menuEl.innerHTML='';
+  var list = [];
+  if(activeCat==='soft'){ list = SOFT_DRINKS; }
+  else{ for(var i=0;i<MENU.length;i++){ if(MENU[i].cat===activeCat) list.push(MENU[i]); } }
+  for(var j=0;j<list.length;j++){
+    var m=list[j];
+    var div=document.createElement('div'); div.className='item';
+    if(m.img){ var img=document.createElement('img'); img.src=m.img; img.alt=''; div.appendChild(img); }
+    var title=document.createElement('div'); title.className='item-title'; title.appendChild(document.createTextNode(m.title)); div.appendChild(title);
+    var desc=document.createElement('div'); desc.className='item-desc'; desc.appendChild(document.createTextNode(m.desc||'')); div.appendChild(desc);
+    var actions=document.createElement('div'); actions.className='item-actions';
+    var select=null; if(m.variants.length>1){
+      select=document.createElement('select');
+      for(var k=0;k<m.variants.length;k++){
+        var opt=document.createElement('option');
+        opt.value=k; opt.appendChild(document.createTextNode(m.variants[k].label+' '+fmtY(m.variants[k].price)));
+        select.appendChild(opt);
+      }
+      actions.appendChild(select);
+    }
+    var btn=document.createElement('button'); btn.appendChild(document.createTextNode('加入购物车'));
+    btn.onclick=(function(m,select){
+      return function(){
+        var v=m.variants[0]; if(select){ v=m.variants[select.value]; }
+        addToCart(m,v);
+      };
+    })(m,select);
+    actions.appendChild(btn);
+    div.appendChild(actions);
+    menuEl.appendChild(div);
+  }
+}
+function cartCount(){ var c=0; for(var i=0;i<CART.length;i++){ c+=CART[i].qty; } return c; }
+function syncCartBtn(){ cartBtn.innerHTML='购物车 · '+cartCount(); }
+function addToCart(m,v){
+  var key=m.id+'|'+v.label;
+  var found=null; for(var i=0;i<CART.length;i++){ if(CART[i]._key===key){ found=CART[i]; break; }}
+  if(found){ found.qty+=1; }
+  else{ CART.push({_key:key,title:m.title,spec:v.label,price:v.price,qty:1}); }
+  saveCart(); renderCart(); cartPanel.style.display='block';
+}
+function changeQty(key,delta){
+  for(var i=0;i<CART.length;i++){
+    if(CART[i]._key===key){ CART[i].qty+=delta; if(CART[i].qty<=0){ CART.splice(i,1); } break; }
+  }
+  saveCart(); renderCart();
+}
+function renderCart(){
+  cartItems.innerHTML='';
+  if(CART.length===0){ var empty=document.createElement('div'); empty.appendChild(document.createTextNode('购物车是空的。')); cartItems.appendChild(empty); }
+  var total=0;
+  for(var i=0;i<CART.length;i++){
+    var line=CART[i]; total+=line.qty*line.price;
+    var ci=document.createElement('div'); ci.className='cart-item';
+    var t=document.createElement('div'); t.className='cart-item-title'; t.appendChild(document.createTextNode(line.title)); ci.appendChild(t);
+    var s=document.createElement('div'); s.className='cart-item-spec'; s.appendChild(document.createTextNode(line.spec)); ci.appendChild(s);
+    var qty=document.createElement('div'); qty.className='cart-item-qty';
+    var minus=document.createElement('button'); minus.appendChild(document.createTextNode('-')); minus.onclick=(function(k){ return function(){ changeQty(k,-1); }; })(line._key);
+    var span=document.createElement('span'); span.appendChild(document.createTextNode(' '+line.qty+' '));
+    var plus=document.createElement('button'); plus.appendChild(document.createTextNode('+')); plus.onclick=(function(k){ return function(){ changeQty(k,1); }; })(line._key);
+    qty.appendChild(minus); qty.appendChild(span); qty.appendChild(plus); ci.appendChild(qty);
+    cartItems.appendChild(ci);
+  }
+  cartTotal.innerHTML=fmtY(total); syncCartBtn();
+}
+cartBtn.onclick=function(){ cartPanel.style.display = cartPanel.style.display==='block' ? 'none' : 'block'; };
+document.getElementById('closeCart').onclick=function(){ cartPanel.style.display='none'; };
+document.getElementById('placeOrder').onclick=function(){
+  if(CART.length===0){ alert('您的购物车是空的'); return; }
+  var order={id:'LC'+(new Date().getTime()), items:CART.slice(0), total:0, created_at:new Date().getTime()};
+  for(var i=0;i<order.items.length;i++){ order.total+=order.items[i].qty*order.items[i].price; }
+  ORDERS.push(order); saveOrders();
+  CART=[]; saveCart(); renderCart(); renderOrders();
+};
+function renderOrders(){
+  ordersList.innerHTML='';
+  for(var i=ORDERS.length-1;i>=0;i--){
+    var o=ORDERS[i];
+    var card=document.createElement('div'); card.className='order-card';
+    var h=document.createElement('h3'); h.appendChild(document.createTextNode('订单 '+o.id)); card.appendChild(h);
+    var items=document.createElement('div');
+    var text='';
+    for(var j=0;j<o.items.length;j++){
+      var l=o.items[j]; text+='• '+l.title+'（'+l.spec+'） × '+l.qty+' '+fmtY(l.qty*l.price)+'\n';
+    }
+    items.appendChild(document.createTextNode(text)); card.appendChild(items);
+    var meta=document.createElement('div'); meta.appendChild(document.createTextNode(new Date(o.created_at).toLocaleString())); card.appendChild(meta);
+    ordersList.appendChild(card);
+  }
+}
+renderTabs();
+renderMenu();
+renderCart();
+renderOrders();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add ipad1.html as simplified menu optimized for early iPad Safari
- implement ES5-style scripts with requestAnimationFrame polyfill and basic cart/order logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c799c14c848330885ac6338a8128fc