### PR TITLE
feat: redesign home screen with xundao style

### DIFF
--- a/images/avatar-immortal.svg
+++ b/images/avatar-immortal.svg
@@ -1,0 +1,19 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">仙者头像</title>
+  <desc id="desc">散发灵光的修仙者头像圆图标。</desc>
+  <defs>
+    <radialGradient id="ring" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#a4f6ff" stop-opacity="1" />
+      <stop offset="45%" stop-color="#6eb7ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#24307c" stop-opacity="0.7" />
+    </radialGradient>
+    <linearGradient id="robe" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#f1fbff" />
+      <stop offset="100%" stop-color="#6d8cfb" />
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="60" fill="url(#ring)" />
+  <path d="M64 30c14 0 26 12 26 28 0 10-6 20-12 24-6 4-16 8-18 8s-12-4-18-8c-6-4-12-14-12-24 0-16 12-28 26-28h8z" fill="#fbfeff" opacity="0.9" />
+  <path d="M42 86c6-4 18-8 22-8s16 4 22 8c8 6 12 14 12 24H30c0-10 4-18 12-24z" fill="url(#robe)" />
+  <path d="M52 52c4-8 12-12 20-12 10 0 18 8 18 18 0 8-4 14-8 18-4 4-12 8-18 8s-14-4-18-8c-4-4-8-10-8-18 0-4 2-10 4-14 2 4 6 8 10 8z" fill="#dcecff" opacity="0.9" />
+</svg>

--- a/images/xundao-bg.svg
+++ b/images/xundao-bg.svg
@@ -1,0 +1,62 @@
+<svg width="1920" height="1080" viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">寻道大千灵境背景</title>
+  <desc id="desc">以蓝紫色灵光渲染的玄幻群山与灵雾。</desc>
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1734" />
+      <stop offset="35%" stop-color="#191f48" />
+      <stop offset="68%" stop-color="#2e1e57" />
+      <stop offset="100%" stop-color="#111422" />
+    </linearGradient>
+    <linearGradient id="sunset" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#5ce7ff" stop-opacity="0.9" />
+      <stop offset="60%" stop-color="#7c5af2" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#ff9ace" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="mist" cx="50%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#c7f7ff" stop-opacity="0.48" />
+      <stop offset="35%" stop-color="#6f87ff" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#18152b" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="ridge1" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2c4f9f" stop-opacity="0.15" />
+      <stop offset="60%" stop-color="#493c8c" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#281551" stop-opacity="0.7" />
+    </linearGradient>
+    <linearGradient id="ridge2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1f3d7a" stop-opacity="0.28" />
+      <stop offset="70%" stop-color="#412b7c" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#220f3f" stop-opacity="0.78" />
+    </linearGradient>
+    <linearGradient id="ridge3" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#192864" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#1c0f30" stop-opacity="0.82" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="40" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bgGradient)" />
+  <ellipse cx="1460" cy="240" rx="420" ry="220" fill="url(#sunset)" filter="url(#glow)" opacity="0.86" />
+  <rect width="1920" height="1080" fill="url(#mist)" />
+  <g opacity="0.9">
+    <path d="M0 708C160 646 278 598 410 612C602 631 720 744 926 712C1132 680 1218 524 1432 544C1574 557 1666 646 1920 624V1080H0V708Z" fill="url(#ridge1)" />
+    <path d="M0 822C224 774 356 704 536 720C756 740 882 886 1094 864C1306 842 1424 666 1640 684C1768 694 1856 774 1920 766V1080H0V822Z" fill="url(#ridge2)" opacity="0.85" />
+    <path d="M0 944C192 898 384 856 604 876C824 896 952 1036 1176 1016C1400 996 1528 848 1748 862C1844 868 1888 910 1920 924V1080H0V944Z" fill="url(#ridge3)" opacity="0.8" />
+  </g>
+  <g opacity="0.45" fill="#c3f3ff">
+    <circle cx="220" cy="180" r="3" />
+    <circle cx="340" cy="260" r="2" />
+    <circle cx="520" cy="120" r="2.5" />
+    <circle cx="860" cy="200" r="2.5" />
+    <circle cx="980" cy="140" r="2" />
+    <circle cx="1240" cy="180" r="3" />
+    <circle cx="1520" cy="120" r="2.2" />
+    <circle cx="1660" cy="200" r="2.6" />
+    <circle cx="1800" cy="160" r="2.4" />
+  </g>
+</svg>

--- a/images/xundao-character.svg
+++ b/images/xundao-character.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="960" viewBox="0 0 640 960" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">寻道者立绘</title>
+  <desc id="desc">披风飘动的玄幻角色剪影，带有灵气流动效果。</desc>
+  <defs>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="20" result="blur" />
+      <feOffset dy="18" in="blur" result="offset" />
+      <feMerge>
+        <feMergeNode in="offset" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <linearGradient id="robe" x1="34%" y1="0%" x2="66%" y2="100%">
+      <stop offset="0%" stop-color="#8af6ff" stop-opacity="0.96" />
+      <stop offset="45%" stop-color="#5c8cff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#362076" stop-opacity="1" />
+    </linearGradient>
+    <linearGradient id="cloak" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#86b6ff" stop-opacity="0.8" />
+      <stop offset="40%" stop-color="#4f49d9" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#1a0d54" stop-opacity="1" />
+    </linearGradient>
+    <linearGradient id="hair" x1="0%" y1="0%" x2="100%" y2="80%">
+      <stop offset="0%" stop-color="#f2fbff" />
+      <stop offset="60%" stop-color="#97b7ff" />
+      <stop offset="100%" stop-color="#3e2b7a" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#6ff6ff" stop-opacity="0.7" />
+      <stop offset="60%" stop-color="#4d79ff" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#321962" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <g filter="url(#shadow)">
+    <ellipse cx="320" cy="876" rx="180" ry="46" fill="#060915" opacity="0.6" />
+  </g>
+  <circle cx="320" cy="360" r="260" fill="url(#glow)" opacity="0.6" />
+  <path d="M292 164c28-46 78-58 114-16 32 38 10 94-18 140-18 30-44 52-72 64-24-20-48-60-52-94-4-40 12-78 28-94z" fill="url(#hair)" />
+  <path d="M202 308c34-40 104-54 156-42 64 14 118 64 140 120 36 94 2 216-44 326-20 48-46 94-96 126-40 24-98 16-142-6-52-26-84-70-94-132-16-96-6-204 34-290 16-36 28-74 46-102z" fill="url(#cloak)" />
+  <path d="M256 348c52-26 118-18 168 26 60 54 72 152 44 244-24 78-72 150-122 188-46 34-102 22-144-12-48-40-80-116-70-196 10-90 46-190 124-250z" fill="url(#robe)" />
+  <path d="M318 184c26-8 50 10 60 44 6 20 8 42 4 60-14 8-24 10-36 8s-24-8-34-20c-12-18-16-48-10-66 4-14 10-22 16-26z" fill="#fafcff" opacity="0.8" />
+  <path d="M212 640c30 26 64 42 94 38 40-6 78-44 104-92 28-50 44-112 30-150-8-18-36-34-54-34-26 0-52 20-70 40-38 44-56 102-72 144-8 22-18 40-32 54z" fill="#c3e5ff" opacity="0.35" />
+  <path d="M440 536c10 24 18 48 18 70 0 46-16 90-42 130-10 14-36 34-68 42-28 6-52 0-74-12 20-20 38-44 52-74 26-50 42-108 58-156 10-28 18-52 24-74 22 18 32 40 32 74z" fill="#72b3ff" opacity="0.42" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,563 +3,601 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-<meta name="format-detection" content="telephone=no">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="La Casa 菜单">
-<meta name="theme-color" content="#111">
-<title>La Casa 电子菜单</title>
+<meta name="theme-color" content="#0b0f21">
+<title>寻道大千 · 灵府主界面</title>
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
 <link rel="manifest" href="manifest.webmanifest">
 <style>
   :root{
-    --bg:#0f0f12; --panel:#14141a; --ink:#f1f1f3; --muted:#b6b8c0;
-    --accent:#e3be77; --accent-2:#a88146; --border:rgba(255,255,255,.12);
-    --fs-base:20px; --fs-h1:30px; --fs-sub:18px; --fs-tab:20px;
-    --fs-name:22px; --fs-desc:18px; --fs-price:22px; --fs-btn:20px;
+    --ink:#f2f6ff;
+    --muted:rgba(210,224,255,.75);
+    --panel:rgba(20,26,58,.68);
+    --panel-strong:rgba(28,38,84,.82);
+    --border:rgba(132,170,255,.28);
+    --accent:#82d8ff;
+    --accent-2:#9e7bff;
+    --danger:#ff9acd;
+    font-size:18px;
   }
-  *{box-sizing:border-box}
-  html,body{height:100%;overscroll-behavior-y:none;}
-  body{margin:0;background:var(--bg);color:var(--ink);
-       font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","PingFang SC","Noto Sans CJK SC","Microsoft YaHei","Helvetica Neue",Arial,sans-serif;
-       -webkit-text-size-adjust:100%; font-size:var(--fs-base); line-height:1.6; letter-spacing:.2px;
-       -webkit-user-select:none;user-select:none;
-       -webkit-touch-callout:none;
-       -webkit-tap-highlight-color:transparent;
-       touch-action:manipulation;}
-  body.standalone header{ padding-top: calc(constant(safe-area-inset-top) + 6px); padding-top: calc(env(safe-area-inset-top) + 6px); }
-  header{position:sticky;top:0;z-index:100;background:linear-gradient(180deg, rgba(15,15,18,.98), rgba(15,15,18,.88) 70%, rgba(15,15,18,0));-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);border-bottom:1px solid var(--border); padding-top: max(0px, constant(safe-area-inset-top)); padding-top: max(0px, env(safe-area-inset-top));}
-  .wrap{max-width:1200px;margin:0 auto;padding:12px 16px}
-  h1{font-size:var(--fs-h1);margin:2px 0 6px}
-  .sub{color:var(--muted);font-size:var(--fs-sub);margin:0 0 10px}
-  .toolbar{display:flex;gap:8px;align-items:center;justify-content:space-between}
-  .btn{background:#23232b;color:#fff;border:1px solid var(--border);border-radius:12px;padding:10px 14px;font-weight:800;font-size:var(--fs-btn);min-height:44px;transition:.2s;white-space:nowrap}
-  .btn[disabled]{opacity:.45}
-  .btn.primary{background:var(--accent-2);border-color:transparent}
-  .btn.small{font-size:18px;padding:10px 12px}
-  .tabs{display:flex;gap:12px;overflow:auto;padding:14px 16px;background:var(--panel);border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
-  .tabs::-webkit-scrollbar{display:none}
-  .tab{white-space:nowrap;padding:14px 20px;border-radius:999px;background:#1b1b23;color:#fff;border:1px solid var(--border);font-weight:800;font-size:var(--fs-tab)}
-  .tab[aria-selected="true"]{background:var(--accent-2);border-color:transparent}
-  main{max-width:1200px;margin:0 auto;padding:16px 0 128px}
-  .carousel{position:relative;margin:12px 16px 0;border-radius:18px;overflow:hidden;background:#0c0c0f;border:1px solid var(--border)}
-  .track{display:flex;gap:16px;padding:16px;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth}
-  .slide{position:relative;flex:0 0 92%;max-width:92%;height:72vw;max-height:660px;scroll-snap-align:center;border-radius:16px;overflow:hidden;background:linear-gradient(135deg,#23232b 0%,#1a1a21 100%);border:1px solid var(--border)}
-  @media (min-width:1024px){ .slide{flex-basis:48%;max-width:48%;height:520px} }
-  @media (orientation: landscape) and (max-height: 744px){
-    .wrap {padding: 0 16px;}
-    h1{font-size:14px; float: left;margin: 0;}
-    .sub{font-size:12px; float: left; margin: 1px 10px;}
-    .cart-fab{bottom:auto!important;top:200px;}
-    main{padding-bottom: 0px;}
+  *, *::before, *::after{box-sizing:border-box;}
+  html,body{height:100%;}
+  body{
+    margin:0;
+    font-family:"SF Pro Display", "PingFang SC", "Microsoft YaHei", sans-serif;
+    color:var(--ink);
+    background:#0b0f21;
+    overflow:hidden;
+    position:relative;
+    letter-spacing:.4px;
+    -webkit-font-smoothing:antialiased;
   }
-  .imgph{width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:#80838f;font-size:18px;background:repeating-linear-gradient(45deg,#202028,#202028 12px,#1a1a21 12px,#1a1a21 24px)}
-  .soft-list{list-style:none;margin:0;padding:16px;font-size:var(--fs-name);line-height:1.8}
-  .soft-item{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;}
-  .soft-item .actions{display:flex;align-items:center;gap:12px;}
-  .soft-item .price{color:var(--accent);font-weight:900;font-size:var(--fs-price);}
-  .slide>img,
-  .thumb img{
-    width:100%;
+  body::before{
+    content:"";
+    position:fixed;
+    inset:0;
+    background:url("images/xundao-bg.svg") center/cover no-repeat;
+    z-index:-2;
+    filter:saturate(1.05);
+  }
+  body::after{
+    content:"";
+    position:fixed;
+    inset:0;
+    background:radial-gradient(circle at 20% 20%,rgba(120,180,255,.35),transparent 52%),
+               radial-gradient(circle at 80% 18%,rgba(255,136,214,.25),transparent 54%),
+               linear-gradient(130deg,rgba(24,36,78,.65),rgba(10,12,28,.2));
+    mix-blend-mode:screen;
+    z-index:-1;
+  }
+  .screen{
+    position:relative;
     height:100%;
-    object-fit:cover;
-    display:block;
+    display:flex;
+    flex-direction:column;
+    padding:clamp(20px,4vh,52px) clamp(24px,5vw,72px);
+    gap:clamp(20px,3vh,36px);
   }
-  .overlay{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(180deg,transparent,rgba(0,0,0,.55) 30%,rgba(0,0,0,.75) 78%);color:#fff;padding:16px 16px 14px}
-  .overlay .name{font-size:var(--fs-name);font-weight:800;line-height:1.25;margin:0 0 6px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-  .overlay .desc{font-size:var(--fs-desc);color:#e9e9ee;line-height:1.5;margin:0;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
-  .overlay .row{display:flex;align-items:flex-end;justify-content:space-between;gap:12px;margin-top:10px;flex-wrap:wrap}
-  .overlay .price{color:var(--accent);font-weight:900;font-size:var(--fs-price);white-space:nowrap}
-  .overlay .actions{display:flex;gap:10px;flex-wrap:wrap}
-  .variant{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-  .chip{border:1px solid var(--border);background:#fff;border-radius:999px;padding:6px 10px;font-size:16px;white-space:nowrap;cursor:pointer}
-  .chip.active{background:var(--accent-2);border-color:transparent;color:#fff}
-  .nav{position:absolute;inset:0;display:flex;justify-content:space-between;align-items:center;pointer-events:none}
-  .arrow{pointer-events:auto;border:none;width:56px;height:56px;border-radius:50%;background:rgba(0,0,0,.42);color:#fff;font-size:28px;display:grid;place-items:center;margin:0 8px;border:1px solid rgba(255,255,255,.24);transition:.2s}
-  .arrow[disabled]{opacity:.35}
-  /* Cart Drawer + Backdrop */
-  .cart-fab{position:fixed;right:22px;bottom:24px;z-index:1;border-radius:999px;padding:20px 26px;font-size:22px;background:var(--accent-2);color:#fff;border:none;box-shadow:0 10px 20px rgba(0,0,0,.35)}
-  .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px);opacity:0;pointer-events:none;transition:.25s;z-index:10000}
-  .backdrop.show{opacity:1;pointer-events:auto}
-  .drawer{position:fixed;right:0;top:0;height:100%;width:min(560px,94vw);z-index:10001;transform:translateX(100%);transition:.35s ease;background:var(--panel);border-left:1px solid var(--border);display:flex;flex-direction:column;box-shadow:-20px 0 40px rgba(0,0,0,.45)}
-  .drawer.open{transform:translateX(0)}
-  .drawer header{background:#111117;border-bottom:1px solid var(--border);position:sticky;top:0;z-index:1;padding-top:max(0px, constant(safe-area-inset-top)); padding-top:max(0px, env(safe-area-inset-top))}
-  .drawer .items{flex:1;overflow:auto;padding:16px}
-  .item{display:grid;grid-template-columns:80px 1fr auto;gap:14px;padding:14px 10px;border-bottom:1px dashed rgba(255,255,255,.1)}
-  .thumb{width:80px;height:80px;border-radius:12px;background:#222;display:flex;align-items:center;justify-content:center;font-size:14px;color:#777}
-  .item-title{font-size:20px;margin:0 0 4px;word-break:break-word}
-  .muted{color:var(--muted);font-size:16px}
-  .qty{display:flex;align-items:center;gap:10px;margin-top:8px;flex-wrap:nowrap}
-  .qty button{background:#2b2b33;border:1px solid var(--border);color:#fff;min-width:42px;height:42px;border-radius:10px;font-size:26px;white-space:nowrap}
-  .qty .remove-btn{margin-left:8px}
-  .line-total{font-weight:900;color:var(--accent);align-self:center;font-size:22px;white-space:nowrap}
-  .drawer .footer{padding:16px;border-top:1px solid var(--border);background:#111117}
-  .summary{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;font-size:22px}
-  .checkout{display:flex;gap:10px;flex-wrap:wrap}
-  .nowrap{white-space:nowrap}
-  /* highlight new line */
-  @keyframes flash{0%{background:rgba(227,190,119,.25)}100%{background:transparent}}
-  .flash{animation:flash 1.2s ease-out 1}
-  /* Orders Page */
-  .page{position:fixed;inset:0;background:var(--bg);display:none;flex-direction:column;z-index:10010}
-  .page.show{display:flex}
-  .page header{background:#111117;border-bottom:1px solid var(--border);padding-top:max(0px, constant(safe-area-inset-top)); padding-top:max(0px, env(safe-area-inset-top))}
-  .order-list{flex:1;overflow:auto;padding:16px 20px}
-  .order-card{background:#17171d;border:1px solid var(--border);border-radius:14px;padding:14px;margin-bottom:12px}
-  .order-card h3{margin:0 0 8px;font-size:22px}
-  .order-items{color:#dcdde4;font-size:18px;line-height:1.6;white-space:pre-wrap}
-  .order-meta{display:flex;justify-content:space-between;align-items:center;margin-top:10px;color:var(--muted);font-size:16px}
+  .top-bar{
+    display:flex;
+    justify-content:space-between;
+    align-items:flex-start;
+    gap:clamp(18px,3vw,40px);
+  }
+  .profile-card{
+    display:flex;
+    align-items:center;
+    gap:clamp(16px,2vw,24px);
+    padding:clamp(16px,2.6vh,22px) clamp(22px,3vw,34px);
+    border-radius:24px;
+    background:var(--panel);
+    border:1px solid var(--border);
+    box-shadow:0 18px 36px rgba(7,11,32,.45);
+    color:inherit;
+    text-align:left;
+    cursor:pointer;
+    transition:transform .35s ease, box-shadow .35s ease;
+    backdrop-filter:blur(16px);
+    -webkit-backdrop-filter:blur(16px);
+  }
+  .profile-card:hover,.profile-card:focus-visible{
+    transform:translateY(-4px);
+    box-shadow:0 24px 46px rgba(30,40,96,.48);
+  }
+  .profile-card img{
+    width:clamp(64px,10vw,88px);
+    height:clamp(64px,10vw,88px);
+    flex-shrink:0;
+    border-radius:32px;
+    border:2px solid rgba(154,214,255,.8);
+    box-shadow:0 12px 28px rgba(64,132,255,.45);
+  }
+  .profile-info h2{
+    margin:0;
+    font-size:clamp(20px,2.8vw,28px);
+    font-weight:700;
+  }
+  .profile-info .title{
+    color:var(--accent);
+    font-size:clamp(14px,2vw,18px);
+    margin-top:4px;
+  }
+  .profile-stats{
+    margin-top:10px;
+    display:flex;
+    flex-wrap:wrap;
+    gap:14px;
+    font-size:clamp(13px,1.6vw,17px);
+    color:var(--muted);
+  }
+  .profile-stats span{
+    display:flex;
+    align-items:center;
+    gap:6px;
+    padding:4px 10px;
+    border-radius:999px;
+    background:rgba(80,114,204,.28);
+    border:1px solid rgba(160,196,255,.24);
+  }
+  .events{
+    display:flex;
+    align-items:center;
+    gap:clamp(12px,1.8vw,20px);
+  }
+  .event-icon{
+    position:relative;
+    width:clamp(58px,8vw,72px);
+    height:clamp(58px,8vw,72px);
+    border-radius:24px;
+    border:1px solid rgba(150,192,255,.35);
+    background:var(--panel-strong);
+    color:var(--ink);
+    display:grid;
+    place-items:center;
+    cursor:pointer;
+    box-shadow:0 12px 24px rgba(16,22,52,.45);
+    transition:transform .25s ease, box-shadow .25s ease;
+    backdrop-filter:blur(12px);
+    -webkit-backdrop-filter:blur(12px);
+  }
+  .event-icon svg{width:60%;height:60%;}
+  .event-icon:hover,.event-icon:focus-visible{
+    transform:translateY(-6px) scale(1.04);
+    box-shadow:0 18px 36px rgba(46,66,136,.55);
+  }
+  .event-icon::after{
+    content:attr(data-label);
+    position:absolute;
+    bottom:-32px;
+    left:50%;
+    transform:translateX(-50%);
+    background:rgba(11,17,42,.78);
+    border:1px solid rgba(140,186,255,.3);
+    color:var(--muted);
+    padding:4px 10px;
+    border-radius:999px;
+    font-size:13px;
+    white-space:nowrap;
+    opacity:0;
+    pointer-events:none;
+    transition:opacity .2s ease, transform .2s ease;
+  }
+  .event-icon:hover::after,
+  .event-icon:focus-visible::after{
+    opacity:1;
+    transform:translate(-50%, -6px);
+  }
+  .hero-area{
+    flex:1;
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:clamp(24px,6vw,80px);
+    pointer-events:none;
+  }
+  .hero-copy{
+    max-width:520px;
+    pointer-events:auto;
+  }
+  .hero-copy .tagline{
+    margin:0 0 12px;
+    font-size:clamp(16px,2.2vw,20px);
+    color:var(--accent);
+    letter-spacing:.6px;
+  }
+  .hero-copy h1{
+    margin:0;
+    font-size:clamp(34px,5vw,54px);
+    font-weight:700;
+    line-height:1.15;
+    text-shadow:0 8px 22px rgba(12,20,48,.58);
+  }
+  .hero-copy p{
+    margin:18px 0 0;
+    font-size:clamp(16px,2.4vw,19px);
+    color:var(--muted);
+    line-height:1.7;
+  }
+  .hero-actions{
+    margin-top:26px;
+    display:flex;
+    gap:16px;
+    pointer-events:auto;
+  }
+  .hero-actions .btn{
+    padding:12px 26px;
+    border-radius:999px;
+    border:1px solid rgba(138,206,255,.42);
+    background:linear-gradient(120deg,rgba(64,132,255,.62),rgba(148,101,255,.58));
+    color:#fff;
+    font-size:16px;
+    font-weight:600;
+    cursor:pointer;
+    box-shadow:0 12px 28px rgba(60,108,198,.52);
+    transition:transform .25s ease, box-shadow .25s ease;
+  }
+  .hero-actions .btn.secondary{
+    background:rgba(20,32,68,.7);
+    border-color:rgba(128,178,255,.32);
+    box-shadow:0 10px 24px rgba(12,20,48,.55);
+  }
+  .hero-actions .btn:hover,.hero-actions .btn:focus-visible{
+    transform:translateY(-3px);
+    box-shadow:0 18px 36px rgba(62,122,230,.6);
+  }
+  .hero-figure{
+    position:relative;
+    flex:1;
+    display:flex;
+    justify-content:center;
+    align-items:flex-end;
+    min-height:340px;
+    pointer-events:none;
+  }
+  .hero-figure::before{
+    content:"";
+    position:absolute;
+    bottom:0;
+    width:72%;
+    max-width:420px;
+    aspect-ratio:1/0.26;
+    background:radial-gradient(circle at 50% 50%,rgba(40,72,160,.72),rgba(6,10,24,0));
+    filter:blur(2px);
+    transform:translateY(30px);
+  }
+  .character-glow{
+    position:absolute;
+    inset:auto;
+    bottom:12%;
+    width:88%;
+    max-width:520px;
+    aspect-ratio:1/1.32;
+    background:radial-gradient(circle at 40% 20%,rgba(130,240,255,.45),rgba(40,60,150,.18) 60%, rgba(12,20,46,0) 100%);
+    filter:blur(0px);
+    animation:breath 6s ease-in-out infinite;
+  }
+  .hero-character{
+    width:88%;
+    max-width:520px;
+    pointer-events:none;
+    animation:float 8s ease-in-out infinite;
+  }
+  .hero-character img{
+    width:100%;
+    height:auto;
+    display:block;
+    filter:drop-shadow(0 22px 40px rgba(18,24,56,.72));
+  }
+  @keyframes float{
+    0%,100%{transform:translateY(0px);} 50%{transform:translateY(-18px);}
+  }
+  @keyframes breath{
+    0%,100%{transform:scale(0.96);} 50%{transform:scale(1.05);}
+  }
+  .bottom-nav{
+    margin-top:auto;
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:14px;
+    padding:16px clamp(18px,4vw,36px);
+    border-radius:28px;
+    background:rgba(12,16,38,.78);
+    border:1px solid rgba(108,156,255,.26);
+    box-shadow:0 24px 48px rgba(6,10,24,.6);
+    backdrop-filter:blur(18px);
+    -webkit-backdrop-filter:blur(18px);
+  }
+  .nav-item{
+    flex:1;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:8px;
+    border:none;
+    background:none;
+    color:var(--muted);
+    cursor:pointer;
+    padding:10px 8px;
+    border-radius:18px;
+    transition:background .25s ease, color .25s ease, transform .25s ease;
+  }
+  .nav-item svg{width:26px;height:26px;fill:currentColor;opacity:.8;}
+  .nav-item span{font-size:13px;}
+  .nav-item.active, .nav-item:hover, .nav-item:focus-visible{
+    background:linear-gradient(135deg,rgba(88,140,255,.38),rgba(158,121,255,.44));
+    color:#fff;
+    transform:translateY(-2px);
+  }
+  .event-panel{
+    position:absolute;
+    top:clamp(120px,16vh,200px);
+    right:clamp(28px,6vw,120px);
+    width:min(320px,58vw);
+    padding:18px 22px;
+    border-radius:20px;
+    background:rgba(20,30,70,.88);
+    border:1px solid rgba(130,186,255,.32);
+    box-shadow:0 18px 38px rgba(10,14,32,.55);
+    backdrop-filter:blur(14px);
+    -webkit-backdrop-filter:blur(14px);
+    opacity:0;
+    transform:translateY(-12px);
+    transition:opacity .35s ease, transform .35s ease;
+    pointer-events:none;
+    color:var(--muted);
+  }
+  .event-panel.show{
+    opacity:1;
+    transform:translateY(0);
+  }
+  .event-panel strong{
+    display:block;
+    color:var(--ink);
+    font-size:18px;
+    margin-bottom:6px;
+  }
+  .event-panel p{margin:0;font-size:15px;line-height:1.6;}
+  .modal-backdrop{
+    position:fixed;
+    inset:0;
+    background:rgba(6,8,18,.78);
+    backdrop-filter:blur(10px);
+    -webkit-backdrop-filter:blur(10px);
+    opacity:0;
+    transition:opacity .3s ease;
+    z-index:40;
+  }
+  .profile-modal{
+    position:fixed;
+    inset:0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    z-index:50;
+    opacity:0;
+    pointer-events:none;
+    transition:opacity .3s ease;
+  }
+  .profile-modal .modal-card{
+    width:min(520px,86vw);
+    background:rgba(12,16,38,.92);
+    border:1px solid rgba(128,176,255,.32);
+    border-radius:28px;
+    box-shadow:0 32px 56px rgba(4,8,20,.65);
+    padding:28px;
+    color:var(--ink);
+    transform:translateY(24px);
+    transition:transform .3s ease;
+    backdrop-filter:blur(18px);
+    -webkit-backdrop-filter:blur(18px);
+  }
+  .profile-modal.show{opacity:1;pointer-events:auto;}
+  .profile-modal.show .modal-card{transform:translateY(0);}
+  .modal-backdrop.show{opacity:1;}
+  .modal-header{
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    gap:16px;
+  }
+  .modal-header h2{margin:0;font-size:24px;}
+  .modal-header button{
+    border:none;
+    background:none;
+    color:var(--muted);
+    cursor:pointer;
+    font-size:16px;
+    padding:4px 8px;
+  }
+  .modal-body{margin-top:18px;line-height:1.8;color:var(--muted);font-size:16px;}
+  .modal-body dl{margin:16px 0 0;display:grid;grid-template-columns:140px 1fr;row-gap:12px;column-gap:18px;}
+  .modal-body dt{color:var(--ink);}
+  .modal-body dd{margin:0;}
+  .modal-footer{margin-top:24px;display:flex;justify-content:flex-end;}
+  .modal-footer .btn{
+    padding:10px 20px;
+    border-radius:999px;
+    border:1px solid rgba(130,186,255,.36);
+    background:rgba(20,32,72,.72);
+    color:var(--ink);
+    cursor:pointer;
+  }
+  .modal-footer .btn:hover,.modal-footer .btn:focus-visible{
+    background:linear-gradient(120deg,rgba(92,148,255,.4),rgba(156,112,255,.5));
+  }
+  @media (max-width:960px){
+    .hero-area{flex-direction:column;align-items:flex-start;}
+    .hero-figure{align-self:center;}
+    .screen{padding:22px 20px 32px;}
+    .top-bar{flex-direction:column;align-items:stretch;}
+    .events{align-self:flex-end;}
+    .event-panel{position:relative;top:auto;right:auto;width:100%;}
+  }
+  @media (max-width:600px){
+    :root{font-size:17px;}
+    body{overflow:hidden;}
+    .profile-card{width:100%;}
+    .events{align-self:flex-start;}
+    .event-icon::after{display:none;}
+    .hero-area{gap:18px;}
+    .bottom-nav{padding:14px 18px;}
+    .nav-item span{font-size:12px;}
+    .modal-body dl{grid-template-columns:1fr;}
+  }
+  @media (prefers-reduced-motion:reduce){
+    *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important;}
+  }
 </style>
 </head>
 <body>
-<header>
-  <div class="wrap">
-    <div class="toolbar">
-      <div>
-        <h1>La Casa 专属隐藏款 · Hidden Treasures</h1>
-        <p class="sub">酒隐之茄专为雪茄客打造的雪茄配饮，经过了反复的测评，能够带来非凡的品茄体验。不同类型的酒，在灰茄前、茄中、茄后兼容性不同。</p>
+<div class="screen">
+  <header class="top-bar">
+    <button class="profile-card" id="profileBtn" type="button" aria-haspopup="dialog" aria-controls="profileModal">
+      <img src="images/avatar-immortal.svg" alt="灵主头像">
+      <div class="profile-info">
+        <h2>云湛子</h2>
+        <div class="title">无极天宫 · 第十三代掌教</div>
+        <div class="profile-stats">
+          <span>境界 · 太虚圆满</span>
+          <span>灵根 · 三灵同辉</span>
+          <span>功德 · 184,520</span>
+        </div>
+      </div>
+    </button>
+    <div class="events" aria-label="当前活动">
+      <button class="event-icon" type="button" data-label="悟道试炼" data-title="悟道试炼" data-desc="九重灵塔限时开放，完成试炼可收集稀有道韵。" aria-describedby="eventPanel">
+        <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M32 6L10 18v28l22 12 22-12V18L32 6zm0 6.6 14 7.6v18.2L32 46l-14-7.6V20.2L32 12.6z" fill="currentColor"/><path d="M32 20l-8 12h6v12h4V32h6L32 20z" fill="currentColor"/></svg>
+      </button>
+      <button class="event-icon" type="button" data-label="宗门盛典" data-title="宗门盛典" data-desc="本周宗门庆典加开，参与可为弟子提升全属性10%。" aria-describedby="eventPanel">
+        <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M12 14h40l-6 32H18l-6-32z" fill="currentColor" opacity="0.72"/><path d="M24 12a8 8 0 0 1 16 0h8v8H16v-8h8z" fill="currentColor"/></svg>
+      </button>
+      <button class="event-icon" type="button" data-label="灵宠入世" data-title="灵宠入世" data-desc="限时召唤灵宠，签订契约后即可解锁新随从动画。" aria-describedby="eventPanel">
+        <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M20 20c0-8 6-14 12-14s12 6 12 14c6 0 10 6 10 12s-4 12-10 12H20c-6 0-10-6-10-12s4-12 10-12z" fill="currentColor"/><circle cx="26" cy="26" r="4" fill="#0b0f21"/><circle cx="38" cy="26" r="4" fill="#0b0f21"/><path d="M24 38c2 4 6 6 8 6s6-2 8-6" stroke="#0b0f21" stroke-width="3" stroke-linecap="round" fill="none"/></svg>
+      </button>
+    </div>
+  </header>
+
+  <div class="event-panel" id="eventPanel" role="status" aria-live="polite" aria-hidden="true"></div>
+
+  <section class="hero-area" aria-label="灵府概览">
+    <div class="hero-copy">
+      <p class="tagline">灵府波动 · 天道回应</p>
+      <h1>寻道大千 · 灵府总览</h1>
+      <p>四海三界灵脉汇聚，九霄星辉护佑。掌教可在此掌控宗门脉络，调遣弟子，洞察天机，俯瞰万象。</p>
+      <div class="hero-actions">
+        <button class="btn" type="button">进入灵府</button>
+        <button class="btn secondary" type="button">观测星图</button>
       </div>
     </div>
-  </div>
-  <nav class="tabs" id="tabs" aria-label="分类切换"></nav>
-</header>
-
-<main id="menuMain">
-  <section class="carousel" aria-label="商品轮播">
-    <div class="track" id="track"></div>
-    <div class="nav" aria-hidden="true">
-      <button class="arrow" id="prev" aria-label="上一屏">‹</button>
-      <button class="arrow" id="next" aria-label="下一屏">›</button>
+    <div class="hero-figure" aria-hidden="true">
+      <div class="character-glow"></div>
+      <div class="hero-character">
+        <img src="images/xundao-character.svg" alt="云湛子立于灵光之中">
+      </div>
     </div>
   </section>
-</main>
 
-<div class="backdrop" id="backdrop"></div>
+  <nav class="bottom-nav" aria-label="主功能导航">
+    <button class="nav-item active" type="button">
+      <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M32 10 8 28v24h16V38h16v14h16V28L32 10z"/></svg>
+      <span>洞天</span>
+    </button>
+    <button class="nav-item" type="button">
+      <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M10 46c4-12 12-22 22-22s18 10 22 22H10z"/><path d="M24 18a8 8 0 0 1 16 0v6H24v-6z"/></svg>
+      <span>炼阁</span>
+    </button>
+    <button class="nav-item" type="button">
+      <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M12 20h40v28H12z"/><path d="M20 16V8h8v8" fill="currentColor"/><path d="M36 16V8h8v8" fill="currentColor"/></svg>
+      <span>宗门</span>
+    </button>
+    <button class="nav-item" type="button">
+      <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M32 12a20 20 0 1 0 0 40 20 20 0 0 0 0-40zm0 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm0 24a12 12 0 0 1-10-6c.2-4 6-6 10-6s9.8 2 10 6a12 12 0 0 1-10 6z"/></svg>
+      <span>灵仆</span>
+    </button>
+    <button class="nav-item" type="button">
+      <svg viewBox="0 0 64 64" aria-hidden="true"><path d="M34 12h16l2 10H34zM12 18h16v10H14zM36 32h16v10H34zM12 36h16l2 10H12z"/></svg>
+      <span>传承</span>
+    </button>
+  </nav>
+</div>
 
-<!-- Cart -->
-<button class="cart-fab" id="cartBtn" aria-label="查看购物车">购物车 · 0</button>
-<aside class="drawer" id="drawer" aria-label="购物车" aria-hidden="true">
-  <header>
-    <div class="wrap" style="display:flex;align-items:center;justify-content:space-between;">
-      <div style="font-weight:800;font-size:22px">我的购物车</div>
-      <button class="btn small" id="closeDrawer">关闭</button>
+<div class="modal-backdrop" id="profileBackdrop" hidden></div>
+<section class="profile-modal" id="profileModal" role="dialog" aria-modal="true" aria-labelledby="profileTitle" hidden>
+  <div class="modal-card">
+    <header class="modal-header">
+      <h2 id="profileTitle">云湛子 · 掌教档案</h2>
+      <button type="button" id="closeProfile" aria-label="关闭档案">关闭</button>
+    </header>
+    <div class="modal-body">
+      <p>天元历三万四千年，云湛子于九霄雷海悟道飞升，现坐镇无极天宫。其下八万弟子，三千护法，百灵护宗。掌控浮光灵阵，可调动十二重天星辰之力。</p>
+      <dl>
+        <dt>功法</dt>
+        <dd>《太虚归一诀》 · 《星瀚流光篇》</dd>
+        <dt>灵器</dt>
+        <dd>镇界天衍盘 · 玄穹万象扇</dd>
+        <dt>弟子总数</dt>
+        <dd>核心弟子 128 名 · 外门弟子 32,480 名</dd>
+        <dt>宗门盟友</dt>
+        <dd>昆仑仙域 · 飞霞古宗 · 北辰剑阁</dd>
+      </dl>
     </div>
-  </header>
-  <div class="items" id="cartItems"></div>
-  <div class="footer">
-    <div class="summary"><span class="t">合计</span><strong id="cartTotal">¥0</strong></div>
-    <div class="checkout">
-      <button class="btn" id="clearCart">清空</button>
-      <button class="btn primary" id="placeOrder">生成订单并查看</button>
-      <button class="btn" id="viewOrders">查看订单</button>
-    </div>
+    <footer class="modal-footer">
+      <button class="btn" type="button" id="closeProfileFooter">收起灵识</button>
+    </footer>
   </div>
-</aside>
-
-<!-- Orders Page -->
-<section class="page" id="ordersPage" aria-label="订单列表页面">
-  <header>
-    <div class="wrap" style="display:flex;align-items:center;justify-content:space-between;">
-      <div style="font-weight:800;font-size:22px">订单列表</div>
-      <div style="display:flex;gap:8px">
-        <button class="btn small" id="backToMenu">返回菜单</button>
-      </div>
-    </div>
-  </header>
-  <div class="order-list" id="ordersList"></div>
 </section>
 
 <script>
-// iOS PWA 独立模式检测，给 body 增加 safe-area 顶部内边距
-(function(){
-  const isStandalone = (window.navigator.standalone === true) || window.matchMedia('(display-mode: standalone)').matches;
-  if(isStandalone){ document.body.classList.add('standalone'); }
-})();
+  const profileBtn = document.getElementById('profileBtn');
+  const profileModal = document.getElementById('profileModal');
+  const profileBackdrop = document.getElementById('profileBackdrop');
+  const closeProfileBtn = document.getElementById('closeProfile');
+  const closeProfileFooter = document.getElementById('closeProfileFooter');
+  const eventPanel = document.getElementById('eventPanel');
+  const eventButtons = document.querySelectorAll('.event-icon');
+  const navItems = document.querySelectorAll('.nav-item');
+  let hideEventTimer = null;
 
-document.addEventListener('gesturestart', e=>e.preventDefault());
-
-let lastTouchEnd = 0;
-document.addEventListener('touchend', e => {
-  const now = Date.now();
-  if (now - lastTouchEnd <= 300) {
-    e.preventDefault();
-  }
-  lastTouchEnd = now;
-}, {passive:false});
-document.addEventListener('dblclick', e=>e.preventDefault(), {passive:false});
-document.addEventListener('contextmenu', e=>e.preventDefault());
-
-let startY = 0, startX = 0;
-document.addEventListener('touchstart', e=>{
-  const t = e.touches[0];
-  startY = t.clientY;
-  startX = t.clientX;
-}, {passive:false});
-document.addEventListener('touchmove', e=>{
-  const t = e.touches[0];
-  const deltaY = t.clientY - startY;
-  const deltaX = t.clientX - startX;
-  // 仅在垂直滑动时阻止顶/底部回弹，保留横向滑动能力
-  if (Math.abs(deltaY) > Math.abs(deltaX)) {
-    const atTop = window.scrollY === 0;
-    const atBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
-    if ((atTop && deltaY > 0) || (atBottom && deltaY < 0)) {
-      e.preventDefault();
-    }
-  }
-}, {passive:false});
-
-// 分类与菜单（支持多规格）
-const CATS=[
-  {id:'coffee',name:'精品咖啡 Coffee'},{id:'rum',name:'古巴朗姆 Rum for Cigar'},
-  {id:'sig',name:'La Casa 特调 Signature Cocktails'},
-  {id:'soft',name:'软饮 Soft Drinks'},
-  {id:'rose',name:'桃红葡萄酒 Rosé'},{id:'rare',name:'小众烈酒 Rare Spirits'},
-  {id:'white',name:'白葡萄酒 White Wine'},{id:'red',name:'红葡萄酒 Red Wine'},
-  {id:'snack',name:'茄客小食'},
-  {id:'easter',name:'La Casa 小彩蛋'}
-];
-const MENU=[
-  // 咖啡（单规格：杯）
-  {id:'ice-1',cat:'coffee',title:'极品冰滴｜淡雅芳香系（百搭雪茄）',desc:'0℃冰水滴滤 1 天，发酵 3–7 天，口感清冽冰爽。',variants:[{label:'杯', unit:'/杯', price:11900}],img:'images/ice-1.jpg'},
-  {id:'ice-2',cat:'coffee',title:'极品冰滴｜果香红茶系（提升风味）',desc:'果香跳跃、红茶感明显，激发雪茄香气。',variants:[{label:'杯', unit:'/杯', price:11900}],img:'images/ice-1.jpg'},
-  {id:'ice-3',cat:'coffee',title:'极品冰滴｜浆果活泼系（适配强度）',desc:'更有劲道的风味线，适配高强度雪茄。',variants:[{label:'杯', unit:'/杯', price:11900}],img:'images/ice-1.jpg'},
-  {id:'hot-1',cat:'coffee',title:'精品手冲｜万花',desc:'参赛级参数调校，层次丰富。',variants:[{label:'杯', unit:'/杯', price:7900}],img:'images/hot-1.jpg'},
-  {id:'hot-2',cat:'coffee',title:'精品手冲｜耶加莱德',desc:'花果香突出，酸甜平衡。',variants:[{label:'杯', unit:'/杯', price:7900}],img:'images/hot-1.jpg'},
-  {id:'hot-3',cat:'coffee',title:'精品手冲｜桃莓优格',desc:'桃与莓果气息，酸乳感顺滑。',variants:[{label:'杯', unit:'/杯', price:7900}],img:'images/hot-1.jpg'},
-  // 朗姆（多规格：杯/瓶）
-  {id:'cubaney-10',cat:'rum',title:'古巴邑 10 年',desc:'顺喉易饮，入门之选。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:98000}],img:'images/cubaney-10.jpg'},
-  {id:'cubaney-20',cat:'rum',title:'古巴邑 20 年',desc:'陈年香气浓郁，回味悠长。',variants:[{label:'瓶',unit:'/瓶',price:339600}],img:'images/cubaney-20.jpg'},
-  {id:'santiago-20',cat:'rum',title:'圣地亚哥 20 年（绝版）',desc:'加勒比热辣与陈年复杂度的平衡。',variants:[{label:'瓶',unit:'/瓶',price:655900}],img:'images/santiago-20.jpg'},
-  {id:'treasure',cat:'rum',title:'金银岛宝藏（国礼）',desc:'收藏级古巴朗姆，气派之选。',variants:[{label:'瓶',unit:'/瓶',price:1799900}],img:'images/treasure.jpg'},
-  // 白葡萄酒
-  {id:'ww-1',cat:'white',title:'南十字星 马尔堡 长相思 干白 2021',desc:'单宁近零，激发味蕾，适合灰茄前/中。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:32800}],img:'images/ww-1.jpg'},
-  {id:'ww-2',cat:'white',title:'勃艮第 法拉利酒庄 小夏布利 村庄 干白 2023',desc:'矿物感清晰，酸度爽脆。',variants:[{label:'瓶',unit:'/瓶',price:68800}],img:'images/ww-2.jpg'},
-  {id:'ww-3',cat:'white',title:'法国 杜索 传统佳酿 香槟',desc:'气泡细腻，活力十足。',variants:[{label:'瓶',unit:'/瓶',price:98900}],img:'images/ww-3.jpg'},
-  // 红葡萄酒
-  {id:'rw-1',cat:'red',title:'摩尔多瓦 梅洛 干红 2012',desc:'适合灰茄后饮用。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:32800}],img:'images/rw-1.jpg'},
-  {id:'rw-2',cat:'red',title:'法芭雅 蒙特布查诺 红 2022',desc:'成熟红果与香料气息。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rw-2.jpg'},
-  {id:'rw-3',cat:'red',title:'曼都利亚 利嘉 红 2021',desc:'饱满酒体，余味绵长。',variants:[{label:'瓶',unit:'/瓶',price:49800}],img:'images/rw-3.jpg'},
-  {id:'rw-4',cat:'red',title:'格兰吉雅 经典 阿玛罗尼 红 2022',desc:'力度与甜美并存。',variants:[{label:'瓶',unit:'/瓶',price:98900}],img:'images/rw-4.jpg'},
-  // 桃红
-  {id:'rose-1',cat:'rose',title:'特莎蒂洛 蓝布鲁斯科 桃红起泡 NV',desc:'全程兼容雪茄，轻松畅饮。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rose-1.jpg'},
-  {id:'rose-2',cat:'rose',title:'时尚控 桃红起泡',desc:'派对气质，愉悦开胃。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rose-2.jpg'},
-  // 小众烈酒
-  {id:'rare-1',cat:'rare',title:'狂爱芒果甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-1.jpg'},
-  {id:'rare-2',cat:'rare',title:'狂爱椰子甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-2.jpg'},
-  {id:'rare-3',cat:'rare',title:'狂爱甜瓜甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-3.jpg'},
-  {id:'rare-4',cat:'rare',title:'狂爱石榴甜性烈酒',desc:'水果炸弹，甜度很高。',variants:[{label:'瓶',unit:'/瓶',price:32800}],img:'images/rare-4.jpg'},
-  {id:'rare-5',cat:'rare',title:'拉达米尔 白兰地',desc:'适合灰茄中/后。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:48000}],img:'images/rare-5.jpg'},
-  {id:'rare-6',cat:'rare',title:'梅斯赫蒂 五年 白兰地',desc:'顺滑果干风味。',variants:[{label:'杯',unit:'/杯',price:6900},{label:'瓶',unit:'/瓶',price:48000}],img:'images/rare-6.jpg'},
-  // 特调
-  {id:'mojito',cat:'sig',title:'比那尔德里奥的莫吉托',desc:'Pinar del Río Mojito · 与雪茄全程兼容。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
-  {id:'cubalibre',cat:'sig',title:'自由古巴之烟草时光',desc:'Cigar Time of Cuba Libre · 经典新演绎。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
-  {id:'castle',cat:'sig',title:'夜之古堡',desc:'Castle in the Night · 夜色与余味。',variants:[{label:'杯',unit:'/杯',price:9800}],img:''},
-  // 小彩蛋 & 小食（单规格）
-  {id:'snack-1',cat:'snack',title:'坚果拼盘',desc:'小胡桃、松子、杏仁、腰果等随机拼盘。',variants:[{label:'盘',unit:'/盘',price:8800}],img:'images/snack-1.jpg'},
-  {id:'snack-2',cat:'snack',title:'伊比利亚火腿',desc:'咸香与脂香，雪茄绝配。',variants:[{label:'盘',unit:'/盘',price:19800}],img:'images/snack-2.jpg'},
-  {id:'snack-3',cat:'snack',title:'黑松露饼干',desc:'幽微松露香气，酥脆可口。',variants:[{label:'盘',unit:'/盘',price:4900}],img:'images/snack-3.jpg'},
-  {id:'bucket-1',cat:'easter',title:'好彩头冰桶｜好运杯',desc:'含可饮白桦树汁，可冰镇任意酒水，会发光。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
-  {id:'bucket-2',cat:'easter',title:'好彩头冰桶｜招财杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
-  {id:'bucket-3',cat:'easter',title:'好彩头冰桶｜吉祥杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'},
-  {id:'bucket-4',cat:'easter',title:'好彩头冰桶｜平安杯',desc:'同款彩光冰桶。',variants:[{label:'桶',unit:'/桶',price:5900}],img:'images/ice-1.jpg'}
-];
-
-const SOFT_DRINKS=[
-  {id:'soft-coke',title:'可乐',variants:[{label:'瓶',unit:'/瓶',price:3000}]},
-  {id:'soft-soda',title:'苏打水',variants:[{label:'瓶',unit:'/瓶',price:3000}]},
-  {id:'soft-baihua',title:'白桦树汁',variants:[{label:'瓶',unit:'/瓶',price:4900}]},
-  {id:'soft-xiguazhi',title:'鲜榨西瓜汁',variants:[{label:'瓶',unit:'/瓶',price:5900}]}
-];
-
-const fmtY = n => '¥' + (n/100).toLocaleString('zh-CN',{minimumFractionDigits:0});
-function el(tag, attrs={}, ...children){
-  const node = document.createElement(tag);
-  for(const [k,v] of Object.entries(attrs||{})){
-    if(k==='class') node.className=v;
-    else if(k.startsWith('on') && typeof v==='function') node.addEventListener(k.slice(2), v);
-    else if(k==='html') node.innerHTML=v;
-    else node.setAttribute(k,v);
-  }
-  for(const c of children.flat()){
-    if(c==null) continue;
-    node.appendChild(typeof c==='string' ? document.createTextNode(c) : c);
-  }
-  return node;
-}
-
-// Tabs + Carousel
-const tabs = document.getElementById('tabs');
-let activeCat = CATS[0].id;
-CATS.forEach(cat=>{
-  const b = el('button',{class:'tab', 'aria-selected': cat.id===activeCat?'true':'false', onclick:()=>{
-    activeCat = cat.id;
-    [...tabs.children].forEach(x=>x.setAttribute('aria-selected','false'));
-    b.setAttribute('aria-selected','true');
-    drawCarousel(true);
-  }}, cat.name);
-  tabs.appendChild(b);
-});
-
-const track = document.getElementById('track');
-const prevBtn=document.getElementById('prev'); const nextBtn=document.getElementById('next');
-const canSmoothScroll = CSS && CSS.supports && CSS.supports('scroll-behavior','smooth');
-function smoothScrollTo(el, left){
-  if(canSmoothScroll){
-    el.scrollTo({left, behavior:'smooth'});
-  }else{
-    const start = el.scrollLeft;
-    const change = left - start;
-    const duration = 300;
-    const startTime = performance.now();
-    function step(now){
-      const progress = Math.min((now - startTime)/duration,1);
-      el.scrollLeft = start + change*progress;
-      if(progress<1) requestAnimationFrame(step);
-    }
-    requestAnimationFrame(step);
-  }
-}
-
-function slideCard(m){
-  const slide = el('div',{class:'slide'});
-  if(m.img){
-    slide.appendChild(el('img',{src:m.img, alt:m.title}));
-  }else{
-    slide.appendChild(el('div',{class:'imgph'}, '图片占位'));
-  }
-  const ov = el('div',{class:'overlay'});
-  ov.appendChild(el('div',{class:'name'}, m.title));
-  ov.appendChild(el('div',{class:'desc'}, m.desc||''));
-
-  // 规格选择（若多规格则显示 chips）
-  let chosen = m.variants[0];
-  let chips = null;
-  if(m.variants.length>1){
-    chips = el('div',{class:'variant'},
-      ...m.variants.map((v,idx)=>{
-        const c = el('button',{class:'chip'+(idx===0?' active':''), onclick:()=>{
-          chosen = v;
-          [...chips.children].forEach(x=>x.classList.remove('active'));
-          c.classList.add('active');
-          priceEl.textContent = fmtY(v.price) + v.unit;
-        }}, `${v.label}`);
-        return c;
-      })
-    );
-    ov.appendChild(chips);
-  }
-  const priceEl = el('div',{class:'price'}, fmtY(chosen.price)+chosen.unit);
-  const row = el('div',{class:'row'},
-    priceEl,
-    el('div',{class:'actions'},
-      el('button',{class:'btn small primary', onclick:()=>addToCart(m, chosen)}, '加入购物车')
-    )
-  );
-  ov.appendChild(row);
-  slide.appendChild(ov);
-  return slide;
-}
-
-function softListSlide(){
-  return el('div',{class:'slide'},
-    el('ul',{class:'soft-list'},
-      ...SOFT_DRINKS.map(m=>{
-        const v = m.variants[0];
-        return el('li',{class:'soft-item'},
-          el('span',{}, m.title),
-          el('div',{class:'actions'},
-            el('span',{class:'price'}, fmtY(v.price)),
-            el('button',{class:'btn small primary', onclick:()=>addToCart(m, v)}, '加入购物车')
-          )
-        );
-      })
-    )
-  );
-}
-
-function drawCarousel(reset=false){
-  track.innerHTML='';
-  if(activeCat==='soft'){
-    track.appendChild(softListSlide());
-  }else{
-    MENU.filter(m=>m.cat===activeCat).forEach(m=> track.appendChild(slideCard(m)));
-  }
-  if(reset){ track.scrollTo({left:0, top:0, behavior:'auto'}); }
-  // Immediately update arrows then defer another update so Safari
-  // has a chance to finalize layout/scroll metrics.
-  updateArrows();
-  requestAnimationFrame(()=> requestAnimationFrame(updateArrows));
-}
-drawCarousel(true);
-
-function updateArrows(){
-  const maxLeft = Math.max(0, track.scrollWidth - track.clientWidth);
-  const atStart = track.scrollLeft <= 1;
-  const atEnd = track.scrollLeft >= maxLeft - 1;
-  prevBtn.disabled = atStart; nextBtn.disabled = atEnd;
-  prevBtn.style.visibility = atStart ? 'hidden' : 'visible';
-  prevBtn.style.pointerEvents = atStart ? 'none' : 'auto';
-  nextBtn.style.visibility = atEnd ? 'hidden' : 'visible';
-  nextBtn.style.pointerEvents = atEnd ? 'none' : 'auto';
-}
-let arrowRaf;
-let arrowTimeout;
-track.addEventListener('scroll', () => {
-  cancelAnimationFrame(arrowRaf);
-  arrowRaf = requestAnimationFrame(updateArrows);
-  clearTimeout(arrowTimeout);
-  arrowTimeout = setTimeout(updateArrows, 100);
-});
-track.addEventListener('scrollend', updateArrows);
-window.addEventListener('resize', updateArrows);
-
-prevBtn.addEventListener('click', ()=>{
-  if(prevBtn.disabled) return;
-  const step = Math.round(track.clientWidth*0.9);
-  const target = Math.max(0, track.scrollLeft - step);
-  smoothScrollTo(track, target);
-});
-
-nextBtn.addEventListener('click', ()=>{
-  if(nextBtn.disabled) return;
-  const step = Math.round(track.clientWidth*0.9);
-  const maxLeft = track.scrollWidth - track.clientWidth;
-  const target = Math.min(maxLeft, track.scrollLeft + step);
-  smoothScrollTo(track, target);
-});
-
-// Cart + Orders
-let CART = JSON.parse(localStorage.getItem('LC_CART_TAB_V9')||'[]'); // 新 key，避免旧数据结构冲突
-let ORDERS = JSON.parse(localStorage.getItem('LC_ORDERS')||'[]');
-const drawer = document.getElementById('drawer');
-const backdrop = document.getElementById('backdrop');
-const cartBtn = document.getElementById('cartBtn');
-const cartItems = document.getElementById('cartItems');
-const cartTotal = document.getElementById('cartTotal');
-const ordersPage = document.getElementById('ordersPage');
-const ordersList = document.getElementById('ordersList');
-
-function persistCart(){ localStorage.setItem('LC_CART_TAB_V9', JSON.stringify(CART)); }
-function persistOrders(){ localStorage.setItem('LC_ORDERS', JSON.stringify(ORDERS)); }
-function cartCount(){ return CART.reduce((a,b)=>a+b.qty,0); }
-function cartSum(){ return CART.reduce((a,b)=>a+b.qty*b.price,0); }
-function syncBtn(){ cartBtn.textContent = '购物车 · ' + cartCount(); }
-
-function addToCart(m, chosen){
-  const label = (chosen && chosen.label) ? chosen.label : m.variants[0].label;
-  const unit = (chosen && chosen.unit) ? chosen.unit : m.variants[0].unit;
-  const price = (chosen && chosen.price) ? chosen.price : m.variants[0].price;
-  const key = m.id + '|' + label;
-  const ex = CART.find(x=>x._key===key);
-  if(ex){
-    ex.qty += 1;
-  }else{
-    CART.push({_key:key, id:m.id, title:m.title, img:m.img, spec:label, unit:'', price:price, qty:1});
-  }
-  persistCart(); renderCart(); openDrawer();
-  cartItems.scrollTop = cartItems.scrollHeight;
-  const last = cartItems.lastElementChild; if(last){ last.classList.add('flash'); setTimeout(()=>last.classList.remove('flash'), 1200); }
-}
-function removeLine(key){ CART = CART.filter(x=>x._key!==key); persistCart(); renderCart(); }
-function changeQty(key, delta){
-  const ex = CART.find(x=>x._key===key); if(!ex) return;
-  ex.qty += delta; if(ex.qty<=0){ removeLine(key); } else { persistCart(); renderCart(); }
-}
-
-function renderCart(){
-  cartItems.innerHTML='';
-  if(CART.length===0){ cartItems.appendChild(el('div',{class:'muted', style:'padding:24px; text-align:center'}, '购物车是空的。')); }
-  CART.forEach(line=>{
-    cartItems.appendChild(el('div',{class:'item'},
-      el('div',{class:'thumb'}, line.img ? el('img',{src:line.img, alt:''}) : '图片'),
-      el('div',{},
-        el('div',{class:'item-title'}, line.title),
-        el('div',{class:'muted'}, `${line.spec}${line.unit}`),
-        el('div',{class:'qty'},
-          el('button',{onclick:()=>changeQty(line._key,-1)},'−'),
-          el('span',{}, String(line.qty)),
-          el('button',{onclick:()=>changeQty(line._key,1)},'+'),
-          el('button',{class:'btn small remove-btn nowrap', onclick:()=>removeLine(line._key)},'移除')
-        )
-      ),
-      el('div',{class:'line-total'}, fmtY(line.price*line.qty))
-    ));
-  });
-  cartTotal.textContent = fmtY(cartSum());
-  syncBtn();
-}
-renderCart();
-function openDrawer(){ drawer.classList.add('open'); drawer.setAttribute('aria-hidden','false'); backdrop.classList.add('show'); }
-function closeDrawer(){ drawer.classList.remove('open'); drawer.setAttribute('aria-hidden','true'); backdrop.classList.remove('show'); }
-document.getElementById('closeDrawer').addEventListener('click', closeDrawer);
-backdrop.addEventListener('click', closeDrawer);
-cartBtn.addEventListener('click', ()=> drawer.classList.contains('open') ? closeDrawer() : openDrawer());
-document.addEventListener('keydown', e=>{ if(e.key==='Escape' && drawer.classList.contains('open')) closeDrawer(); });
-document.getElementById('clearCart').addEventListener('click', ()=>{ CART=[]; persistCart(); renderCart(); });
-
-// 订单页
-function showOrders(){ renderOrders(); ordersPage.classList.add('show'); window.scrollTo(0,0); }
-function hideOrders(){ ordersPage.classList.remove('show'); }
-document.getElementById('backToMenu').addEventListener('click', hideOrders);
-document.getElementById('viewOrders').addEventListener('click', showOrders);
-
-function renderOrders(){
-  ordersList.innerHTML='';
-  if(!ORDERS.length){
-    ordersList.appendChild(el('div',{class:'muted',style:'padding:24px;text-align:center'},'暂无订单。'));
-    return;
-  }
-  [...ORDERS].slice().reverse().forEach(o=>{
-    const itemsText = o.items.map(l=>`• ${l.title}（${l.spec}${l.unit}） × ${l.qty}   ${fmtY(l.qty*l.price)}`).join('\n');
-    const card = el('div',{class:'order-card'},
-      el('h3',{}, `订单 ${o.id}`),
-      el('div',{class:'order-items'}, itemsText),
-      el('div',{class:'order-meta'},
-        el('span',{}, new Date(o.created_at).toLocaleString('zh-CN')),
-        el('strong',{}, fmtY(o.total))
-      )
-    );
-    ordersList.appendChild(card);
-  });
-}
-
-document.getElementById('placeOrder').addEventListener('click', ()=>{
-  if(!CART.length){ alert('您的购物车是空的'); return; }
-  const order = {
-    id: 'LC' + Date.now().toString().slice(-8),
-    items: CART.map(l=>({title:l.title, spec:l.spec, unit:l.unit, qty:l.qty, price:l.price})),
-    total: cartSum(),
-    created_at: Date.now()
-  };
-  ORDERS.push(order); persistOrders();
-  CART=[]; persistCart(); renderCart(); closeDrawer();
-  showOrders();
-});
-
-// 绘制环形文字（按字符宽度分配角度；带 30° 间隔；中心“茄”）
-function drawRingText(ctx, text, radius, startAngle, spacingPx){
-  ctx.save(); ctx.rotate(startAngle);
-  const chars=[...text];
-  for(let i=0;i<chars.length;i++){
-    const ch=chars[i];
-    const w=ctx.measureText(ch).width + spacingPx;
-    const ang = w / radius;
-    ctx.rotate(ang/2);
-    ctx.save(); ctx.translate(0,-radius); ctx.rotate(Math.PI/2);
-    ctx.fillText(ch, -ctx.measureText(ch).width/2, 0);
-    ctx.restore();
-    ctx.rotate(ang/2);
-  }
-  ctx.restore();
-}
-</script>
-<script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-      navigator.serviceWorker.register('sw.js');
+  function openProfile(){
+    profileModal.hidden = false;
+    profileBackdrop.hidden = false;
+    requestAnimationFrame(() => {
+      profileModal.classList.add('show');
+      profileBackdrop.classList.add('show');
     });
   }
+
+  function closeProfile(){
+    profileModal.classList.remove('show');
+    profileBackdrop.classList.remove('show');
+    const prefersReduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if(prefersReduce){
+      profileModal.hidden = true;
+      profileBackdrop.hidden = true;
+    }else{
+      const finish = () => {
+        clearTimeout(fallback);
+        profileModal.hidden = true;
+        profileBackdrop.hidden = true;
+      };
+      const fallback = setTimeout(finish, 320);
+      profileModal.addEventListener('transitionend', finish, {once:true});
+    }
+  }
+
+  profileBtn.addEventListener('click', openProfile);
+  closeProfileBtn.addEventListener('click', closeProfile);
+  closeProfileFooter.addEventListener('click', closeProfile);
+  profileBackdrop.addEventListener('click', closeProfile);
+  document.addEventListener('keydown', evt => {
+    if(evt.key === 'Escape' && !profileModal.hidden){
+      closeProfile();
+    }
+  });
+
+  eventButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const title = btn.dataset.title;
+      const desc = btn.dataset.desc;
+      eventPanel.innerHTML = `<strong>${title}</strong><p>${desc}</p>`;
+      eventPanel.classList.add('show');
+      eventPanel.setAttribute('aria-hidden', 'false');
+      clearTimeout(hideEventTimer);
+      hideEventTimer = setTimeout(() => {
+        eventPanel.classList.remove('show');
+        eventPanel.setAttribute('aria-hidden', 'true');
+      }, 3600);
+    });
+  });
+
+  navItems.forEach(item => {
+    item.addEventListener('click', () => {
+      navItems.forEach(other => other.classList.remove('active'));
+      item.classList.add('active');
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the former menu layout with a single-screen "寻道大千" style landing view
- add immersive background, animated character illustration, and new navigation/event components
- introduce modal profile details and supporting SVG artwork assets

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d392e111408330992b98e895b27097